### PR TITLE
add debugConsumer to allow asserting and relaying debug messages 

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -38,8 +38,8 @@ repositories {
 }
 
 group = 'org.jodd'
-//version = '6.0.0.' + timestamp() + "-SNAPSHOT"
-version = '6.0.5'
+version = '6.0.5.' + timestamp() + "-SNAPSHOT"
+//version = '6.0.5'
 
 rootProject.description = 'Java Mail client'
 

--- a/src/main/java/jodd/mail/ImapServer.java
+++ b/src/main/java/jodd/mail/ImapServer.java
@@ -91,7 +91,8 @@ public class ImapServer extends MailServer<ReceiveMailSession> {
 			PROTOCOL_IMAP,
 			createSessionProperties(),
 			authenticator,
-			attachmentStorage);
+			attachmentStorage,
+				debugConsumer);
 	}
 
 }

--- a/src/main/java/jodd/mail/MailServer.java
+++ b/src/main/java/jodd/mail/MailServer.java
@@ -30,6 +30,7 @@ import javax.mail.Session;
 import java.io.File;
 import java.util.Objects;
 import java.util.Properties;
+import java.util.function.Consumer;
 
 public abstract class MailServer<MailSessionImpl extends MailSession> {
 
@@ -91,6 +92,7 @@ public abstract class MailServer<MailSessionImpl extends MailSession> {
 	protected final File attachmentStorage;
 
 	protected final boolean debugMode;
+	protected final Consumer<String> debugConsumer;
 
 	/**
 	 * Whether strict address checking is turned on.
@@ -117,6 +119,7 @@ public abstract class MailServer<MailSessionImpl extends MailSession> {
 		this.timeout = builder.timeout;
 		this.strictAddress = builder.strictAddress;
 		this.debugMode = builder.debug;
+		this.debugConsumer = builder.debugConsumer;
 		this.customProperties = builder.customProperties;
 	}
 
@@ -176,6 +179,7 @@ public abstract class MailServer<MailSessionImpl extends MailSession> {
 		private Authenticator authenticator;
 		private File attachmentStorage;
 		private boolean debug;
+		private Consumer<String> debugConsumer;
 		private int timeout = 0;
 		private boolean strictAddress = true;
 		private Properties customProperties = new Properties();
@@ -258,7 +262,16 @@ public abstract class MailServer<MailSessionImpl extends MailSession> {
 			return this;
 		}
 
-
+		/**
+		 * Set debug consumer
+		 *
+		 * @param consumer a String consumer to be called for debug logging. By default, this is null.
+		 * @return this
+		 */
+		public Builder debugConsumer(Consumer<String> consumer) {
+			this.debugConsumer = consumer;
+			return this;
+		}
 		/**
 		 * Defines timeout value in milliseconds for all mail-related operations.
 		 *
@@ -325,5 +338,6 @@ public abstract class MailServer<MailSessionImpl extends MailSession> {
 			}
 			return new SmtpServer(this);
 		}
+
 	}
 }

--- a/src/main/java/jodd/mail/Pop3Server.java
+++ b/src/main/java/jodd/mail/Pop3Server.java
@@ -87,7 +87,7 @@ public class Pop3Server extends MailServer<ReceiveMailSession> {
 	 * {@inheritDoc}
 	 *
 	 * @return {@link ReceiveMailSession}
-	 * @see EmailUtil#createSession(String, Properties, Authenticator, File)
+	 * @see EmailUtil#createSession(String, Properties, Authenticator, File, java.util.function.Consumer)
 	 */
 	@Override
 	public ReceiveMailSession createSession() {
@@ -95,7 +95,7 @@ public class Pop3Server extends MailServer<ReceiveMailSession> {
 			PROTOCOL_POP3,
 			createSessionProperties(),
 			authenticator,
-			attachmentStorage);
+			attachmentStorage, debugConsumer);
 	}
 
 }

--- a/src/test/java/jodd/mail/FilterGreenIMAPTest.java
+++ b/src/test/java/jodd/mail/FilterGreenIMAPTest.java
@@ -86,7 +86,7 @@ class FilterGreenIMAPTest {
 			final ImapServer imapServer = MailServer.create()
 				.host(LOCALHOST)
 				.port(3143)
-				.auth(GREEN, PWD)
+				.auth(GREEN, PWD).debugMode(true).debugConsumer(a->System.err.println("CONSUMED!" + a))
 				.buildImapMailServer();
 
 			final ReceiveMailSession session = imapServer.createSession();


### PR DESCRIPTION
main usecase is to be able to relay debug messages to logger.
secondary is it allows for easy asserts to catch unexpected connections/queries.