### PR TITLE
EMLParser.java: make `parse(InputStream)` method public

### DIFF
--- a/src/main/java/jodd/mail/EMLParser.java
+++ b/src/main/java/jodd/mail/EMLParser.java
@@ -116,7 +116,7 @@ public class EMLParser extends EMLProperties<EMLParser> {
 	 * @return {@link ReceivedEmail}.
 	 * @throws MessagingException if {@link MimeMessage} cannot be created.
 	 */
-	protected ReceivedEmail parse(final InputStream emlContentInputStream) throws MessagingException {
+	public ReceivedEmail parse(final InputStream emlContentInputStream) throws MessagingException {
 		if (getSession() == null) {
 			createSession(getProperties());
 		}


### PR DESCRIPTION
Hey!
I looked at the `parse` methods of [`EMLParser`](https://github.com/oblac/jodd-mail/blob/master/src/main/java/jodd/mail/EMLParser.java) and noticed that only the [`parse(InputStream)`](https://github.com/oblac/jodd-mail/blob/7ea837d14242f62f92cece99206c7b97297cde09/src/main/java/jodd/mail/EMLParser.java#L119) isn't public.

I cannot find a reason why that should be intentional. Is there one?
If not, please accept this PR.

Last time I just wrote an issue, this time I wanted to make it easier for you. So you just have to accept/reject this PR ^-^