### PR TITLE
Optimize usage of FileDataSource with AttachmentStorage

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -56,12 +56,12 @@ java {
 dependencies {
 
 	api 'org.jodd:jodd-util:6.0.+'
-	implementation 'jakarta.mail:jakarta.mail-api:2.1.2'
-	implementation 'org.eclipse.angus:jakarta.mail:2.0.2'
+	implementation 'jakarta.mail:jakarta.mail-api:2.1.5'
+	implementation 'org.eclipse.angus:jakarta.mail:2.0.5'
 
 	testImplementation 'org.junit.jupiter:junit-jupiter-api:5.9.+'
 	testRuntimeOnly 'org.junit.jupiter:junit-jupiter-engine:5.9.+'
-	testImplementation 'com.icegreen:greenmail:2.0.0-alpha-3'
+	testImplementation 'com.icegreen:greenmail:2.1.8'
 }
 
 jar {

--- a/src/main/java/jodd/mail/EmailAttachmentBuilder.java
+++ b/src/main/java/jodd/mail/EmailAttachmentBuilder.java
@@ -136,7 +136,11 @@ public class EmailAttachmentBuilder {
 	 */
 	public <T extends DataSource> EmailAttachmentBuilder content(final T dataSource) {
 		this.dataSource = dataSource;
-		name(dataSource.getName());
+		// FileDataSource backed by a file in attachmentStorage may use an internal filename like {messageid}-{attCount}.
+		// So only set this public name implicitly if it was not set explicitly already.
+		if (name == null){
+			name(dataSource.getName());
+		}
 		return this;
 	}
 
@@ -224,14 +228,13 @@ public class EmailAttachmentBuilder {
 	 * @return {@link EmailAttachment}.
 	 * @throws MailException if issue with {@link DataSource}.
 	 */
-	public EmailAttachment<FileDataSource> buildFileDataSource(final String messageId, final File attachmentStorage) throws MailException {
+	public EmailAttachment<FileDataSource> buildFileDataSource(final String fileName, final File attachmentStorage) throws MailException {
 		try {
 			final FileDataSource fds;
 			if (dataSource instanceof FileDataSource) {
 				fds = (FileDataSource) dataSource;
 			} else {
-				final File file = new File(attachmentStorage, sanitizeFileName(messageId));
-				FileUtil.writeStream(file, dataSource.getInputStream());
+				final File file = writeToAttachmentStore(dataSource.getInputStream(), attachmentStorage, fileName);
 				fds = new FileDataSource(file);
 			}
 			checkDataSource();
@@ -239,6 +242,12 @@ public class EmailAttachmentBuilder {
 		} catch (final IOException ioexc) {
 			throw new MailException(ioexc);
 		}
+	}
+
+	File writeToAttachmentStore(InputStream is, File attachmentStorage, String fileName) throws IOException {
+		File file = new File(attachmentStorage, sanitizeFileName(fileName));
+		FileUtil.writeStream(file, is);
+		return file;
 	}
 
 	/**

--- a/src/main/java/jodd/mail/ReceivedEmail.java
+++ b/src/main/java/jodd/mail/ReceivedEmail.java
@@ -25,6 +25,7 @@
 
 package jodd.mail;
 
+import jakarta.activation.FileDataSource;
 import jakarta.mail.Address;
 import jakarta.mail.Flags;
 import jakarta.mail.Message;
@@ -443,12 +444,16 @@ public class ReceivedEmail extends CommonEmail<ReceivedEmail> {
 	 */
 	private ReceivedEmail addAttachment(final Part part, final InputStream content, final File attachmentStorage) throws MessagingException, IOException {
 		final EmailAttachmentBuilder builder = addAttachmentInfo(part);
-		builder.content(content, part.getContentType());
 		if (attachmentStorage != null) {
-			final String name = sanitizeFileName(messageId) + "-" + (this.attachments().size() + 1);
-			return storeAttachment(builder.buildFileDataSource(name, attachmentStorage));
+			// If we have an attachmentStorage, we can save memory by consequently using FileDataSource.
+			final String attStoreFileName = sanitizeFileName(messageId) + "-" + (this.attachments().size() + 1);
+			final File attStoreFile = builder.writeToAttachmentStore(content, attachmentStorage, attStoreFileName);
+			builder.content(new FileDataSource(attStoreFile));
+			return storeAttachment(builder.buildFileDataSource(attStoreFileName, attachmentStorage));
+		} else {
+			builder.content(content, part.getContentType());
+			return storeAttachment(builder.buildByteArrayDataSource());
 		}
-		return storeAttachment(builder.buildByteArrayDataSource());
 	}
 
 	/**

--- a/src/test/java/jodd/mail/AttachmentStorageTest.java
+++ b/src/test/java/jodd/mail/AttachmentStorageTest.java
@@ -71,11 +71,10 @@ class AttachmentStorageTest {
 	}
 
 	@Test
-	@EnabledOnOs(value = {OS.AIX, OS.LINUX, OS.MAC, OS.SOLARIS})
+	@EnabledOnOs(value = {OS.AIX, OS.LINUX, OS.MAC, OS.SOLARIS, OS.WINDOWS})
 	void testAttachmentStorage() throws Exception {
-		// storing files with its message-id as file name fails on windows because value of the message-id consists of brackets
-		//		file names with brackets are not valid on window hosts
-		// see https://tools.ietf.org/html/rfc5322#section-3.6.4
+		// Used to be deactivated for Windows because of <> brackets, but filename sanitation
+		// was implemented in https://github.com/oblac/jodd-mail/issues/19
 
 		final SmtpServer smtpServer = MailServer.create()
 			.host(LOCALHOST)


### PR DESCRIPTION
Hi @igr,

i was optimizing the memory usage of my application and checking where humongous objects were allocated when processing emails with large attachments.

I was already using a streamed MimeMessage as input and also had configured an attachmentStorage folder. But for each attachment there was still a large byte array beeing allocated. Passing an inputStream to the .content method would always create a byte array.

So i have streamlined the usage of FileDataSource in this MR to have a minimal memory footprint.

Would be great if you could check my changes.

Best Regards
ganomi